### PR TITLE
Fix -Werror=stringop-overflow=

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1972,7 +1972,7 @@ DEFINE GCC5_RISCV_ALL_DLINK_COMMON                = -nostdlib -Wl,-n,-q,--gc-sec
 DEFINE GCC5_RISCV_ALL_DLINK_FLAGS                 = DEF(GCC5_RISCV_ALL_DLINK_COMMON) -Wl,--entry,$(IMAGE_ENTRY_POINT) -u $(IMAGE_ENTRY_POINT) -Wl,-Map,$(DEST_DIR_DEBUG)/$(BASE_NAME).map
 DEFINE GCC5_RISCV_ALL_DLINK2_FLAGS                = -Wl,--defsym=PECOFF_HEADER_SIZE=0x220,--script=$(EDK_TOOLS_PATH)/Scripts/GccBase.lds
 DEFINE GCC5_RISCV_ALL_ASM_FLAGS                   = -c -x assembler -imacros $(DEST_DIR_DEBUG)/AutoGen.h
-DEFINE GCC5_RISCV_ALL_CC_FLAGS_WARNING_DISABLE    = -Wno-tautological-compare -Wno-pointer-compare -Wno-stringop-overflow
+DEFINE GCC5_RISCV_ALL_CC_FLAGS_WARNING_DISABLE    = -Wno-tautological-compare -Wno-pointer-compare
 
 DEFINE GCC5_RISCV_OPENSBI_TYPES                   = -DOPENSBI_EXTERNAL_SBI_TYPES=OpensbiTypes.h
 

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.c
@@ -285,7 +285,7 @@ UsbHcBulkTransfer (
   IN  UINT8                               DevSpeed,
   IN  UINTN                               MaxPacket,
   IN  UINT8                               BufferNum,
-  IN  OUT VOID                            *Data[EFI_USB_MAX_BULK_BUFFER_NUM],
+  IN  OUT VOID                            *Data[],
   IN  OUT UINTN                           *DataLength,
   IN  OUT UINT8                           *DataToggle,
   IN  UINTN                               TimeOut,

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbUtility.h
@@ -149,7 +149,7 @@ UsbHcBulkTransfer (
   IN  UINT8                               DevSpeed,
   IN  UINTN                               MaxPacket,
   IN  UINT8                               BufferNum,
-  IN  OUT VOID                            *Data[EFI_USB_MAX_BULK_BUFFER_NUM],
+  IN  OUT VOID                            *Data[],
   IN  OUT UINTN                           *DataLength,
   IN  OUT UINT8                           *DataToggle,
   IN  UINTN                               TimeOut,


### PR DESCRIPTION
The "Disable warning" patch did not fix the problem for me. We should use the upstream patch.